### PR TITLE
fix: update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1588,9 +1588,9 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-mzxOTaU4AsJhnIujhngm+OnA6JX4fTI8D5H26wwGd+BJ57bW70oyRwTqo6EFJm1jTZ7hCo7yVzH1vB8TMFd2ww=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
-    "lodash": "^4.17.16",
+    "lodash": "^4.17.20",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",


### PR DESCRIPTION
Build is currently broken with `"lodash": "^4.17.16"`. This updates it to the latest.