### PR TITLE
fix: Migrate openOverlay to openNerdlet

### DIFF
--- a/nerdlets/event-stream/components/event-table.js
+++ b/nerdlets/event-stream/components/event-table.js
@@ -8,17 +8,17 @@ import { nrdbQuery } from '../lib/utils';
 import { navigation } from 'nr1';
 
 function openChartBuilder(query, account) {
-  const nerdlet = {
-    id: 'data-exploration.nrql-editor',
+  navigation.openNerdlet({
+    id: 'unified-data-exploration.share',
     urlState: {
-      initialActiveInterface: 'nrqlEditor',
-      initialChartType: 'json',
-      initialAccountId: account,
-      initialNrqlValue: query,
-      isViewingQuery: true,
+      widget: {
+        visualization: { id: 'viz.json' },
+        rawConfiguration: {
+          nrqlQueries: [{ query, accountIds: [account] }],
+        },
+      },
     },
-  };
-  navigation.openOverlay(nerdlet);
+  });
 }
 
 export default class EventTable extends React.PureComponent {

--- a/nerdlets/event-stream/components/menu-bar.js
+++ b/nerdlets/event-stream/components/menu-bar.js
@@ -34,17 +34,17 @@ function Filter({ attribute, value, removeFilter }) {
 }
 
 function openChartBuilder(query, account) {
-  const nerdlet = {
-    id: 'data-exploration.nrql-editor',
+  navigation.openNerdlet({
+    id: 'unified-data-exploration.share',
     urlState: {
-      initialActiveInterface: 'nrqlEditor',
-      initialChartType: 'table',
-      initialAccountId: account,
-      initialNrqlValue: query,
-      isViewingQuery: true,
+      widget: {
+        visualization: { id: 'viz.table' },
+        rawConfiguration: {
+          nrqlQueries: [{ query, accountIds: [account] }],
+        },
+      },
     },
-  };
-  navigation.openOverlay(nerdlet);
+  });
 }
 
 export default class MenuBar extends React.PureComponent {


### PR DESCRIPTION
The `navigation.openOverlay` API is being removed from the New Relic One platform. This PR migrates the two call sites in `menu-bar.js` and `event-table.js` to `navigation.openNerdlet`, pointing at the `unified-data-exploration.share` nerdlet (the supported replacement for opening the NRQL editor from a third-party nerdpack).

**How to test:**
- Open an event stream view, click the "Open in chart builder" action on a NRQL result, and confirm the NRQL editor opens with the original query pre-filled in the expected visualization